### PR TITLE
Fix markdown formatting bug

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -67,10 +67,13 @@ if monitor and email_id and app_password:
                         st.subheader("Body:")
                         st.write(body)
                         
-                        st.markdown(f'''## Team to which this mail should be forwarded to:\n
-```
-{return_ans(f"From: {sender}\n\nSubject: {subject}\n\nBody: {body}")['team']}
-```''')
+                        team = return_ans(
+                            f"From: {sender}\n\nSubject: {subject}\n\nBody: {body}"
+                        )["team"]
+                        st.markdown(
+                            f"## Team to which this mail should be forwarded to:\n"
+                            f"```{team}```"
+                        )
             
             
         with st.spinner('Checking for mail...'):

--- a/src/lib/info.py
+++ b/src/lib/info.py
@@ -80,4 +80,4 @@ def RAWEmail(mail: EmailMessage) -> str:
 
     return: Raw email
     """
-    return mail.decode('utf-8')
+    return mail.as_string()


### PR DESCRIPTION
## Summary
- escape triple-quote by generating the output string separately in Streamlit app
- fix RAWEmail helper to use `as_string()`

## Testing
- `python -m py_compile src/app.py src/lib/attachments.py src/lib/forward.py src/lib/info.py src/lib/celery.py src/lib/summarize.py src/llm.py`

## Summary by Sourcery

Fix markdown formatting in the Streamlit app and correct the RAWEmail helper to use as_string() for raw email output.

Bug Fixes:
- Escape triple backticks properly when rendering the team code block in the Streamlit app
- Use EmailMessage.as_string() in RAWEmail helper instead of decoding bytes